### PR TITLE
chore: add per-adaptor reference pages for Airbus, Planet, and Open Cosmos

### DIFF
--- a/docs/reference/services/airbus-adaptor.md
+++ b/docs/reference/services/airbus-adaptor.md
@@ -1,0 +1,154 @@
+---
+title: Airbus Adaptor
+doc_status: unreviewed
+tags:
+  - commercial-data
+  - stac
+  - workflows
+last_reviewed:
+reviewed_by:
+review_notes:
+---
+# Airbus Adaptor
+
+Reference for the Airbus commercial data adaptors, which order satellite imagery from the Airbus OneAtlas API and deliver it into an EO DataHub workspace. Two separate adaptors are provided — one for optical imagery and one for SAR (Synthetic Aperture Radar) — each running as a short-lived Kubernetes pod orchestrated by a CWL workflow.
+
+**How-to:** [Test commercial data adaptor changes](../../how-to/data-and-catalogues/test-commercial-data-adaptor.md) · **Explanation:** [Commercial Data Purchasing Pipeline](../../explanation/architecture/commercial-data-purchasing.md)
+
+For operator-level secrets setup (OTP XOR mechanism, kubectl sanity checks), see [Data Adaptors — Airbus workspace secrets](data-adaptors.md#airbus-workspace-secrets-operator-reference).
+
+## Execution Model
+
+Two CWL workflows are provided:
+
+- **`airbus-optical.cwl`** — wraps a `CommandLineTool` that pulls `public.ecr.aws/eodh/airbus-optical-adaptor:0.0.7` and invokes `python -m airbus_optical_adaptor`.
+- **`airbus-sar.cwl`** — wraps a `CommandLineTool` that pulls `public.ecr.aws/eodh/airbus-sar-adaptor:0.0.11` and invokes `python -m airbus_sar_adaptor`.
+
+Both inject `CLUSTER_PREFIX` as an environment variable and produce the working directory (`.`) as their output, which contains the STAC records written during execution.
+
+A third workflow, **`airbus-optical-multi.cwl`**, accepts an array of STAC directories (`stac_keys`) for batch optical orders but is not in active use.
+
+- **Source code:** [EO-DataHub/commercial-data-adaptors](https://github.com/EO-DataHub/commercial-data-adaptors)
+
+## Inputs
+
+### Optical (`airbus-optical.cwl`)
+
+| Parameter | Description |
+|---|---|
+| `workspace` | Workspace identifier within the platform |
+| `workspace_bucket` | S3 bucket where workspace STAC records are stored |
+| `commercial_data_bucket` | S3 bucket where Airbus delivers order archives |
+| `pulsar_url` | Apache Pulsar broker URL for downstream event messaging |
+| `cluster_prefix` | Platform environment prefix (injected as `CLUSTER_PREFIX`) |
+| `product_bundle` | Named bundle controlling processing parameters: `Visual`, `General Use`, `Analytic`, or `Basic` |
+| `coordinates` | Area of interest coordinates (JSON-stringified) |
+| `stac_key` | Directory containing one or more STAC catalogs describing items to order |
+| `end_users` | JSON-stringified list of end-user names and nationalities — required for PNEO orders |
+| `licence` | Licence identifier applied to the order |
+
+### SAR (`airbus-sar.cwl`)
+
+| Parameter | Description |
+|---|---|
+| `workspace` | Workspace identifier within the platform |
+| `workspace_bucket` | S3 bucket where workspace STAC records are stored |
+| `commercial_data_bucket` | S3 bucket where Airbus delivers order archives |
+| `pulsar_url` | Apache Pulsar broker URL for downstream event messaging |
+| `cluster_prefix` | Platform environment prefix (injected as `CLUSTER_PREFIX`) |
+| `product_bundle` | JSON-stringified object containing `product_type` (SSC/MGD/GEC/EEC), `orbit` (rapid/science), `resolution` (RE/SE), and `projection` (auto/UTM/UPS) |
+| `coordinates` | Area of interest coordinates (JSON-stringified) |
+| `stac_key` | Directory containing one or more STAC catalogs describing items to order |
+| `licence` | Order template identifier applied to the order |
+
+## Processing Pipeline
+
+Both adaptors share the same high-level pipeline, with sensor-specific differences noted below.
+
+### Optical
+
+For each STAC item found in the input catalogs, the adaptor executes the following steps in sequence, aborting the item and writing a failure record on any error:
+
+1. **Authenticate** — Retrieves an OTP key from a Kubernetes Secret (`otp-airbus` in the workspace namespace), fetches the corresponding encrypted API key from AWS Secrets Manager, and decrypts it using XOR One-Time Pad. The plaintext key is exchanged for a short-lived OAuth2 bearer token via the OneAtlas IDP at `authenticate.foundation.api.oneatlas.airbus.com`.
+
+2. **Resolve contract** — Looks up the correct contract ID from the `otp-airbus` Kubernetes Secret (stored base64-encoded under the `contracts` key), selecting the appropriate contract by collection type: `PNEO` contracts for `airbus_pneo_data`, and `LEGACY` contracts for `airbus_phr_data` and `airbus_spot_data`.
+
+3. **Resolve multi-acquisition items** — Detects whether a STAC item contains a `composed_of_acquisition_identifiers` property. If so, all constituent acquisition items are grouped into a single order. Items that are components of a multi-acquisition group are skipped when encountered directly.
+
+4. **Submit order** — POSTs an order to `https://order.api.oneatlas.airbus.com/api/v1/orders`. The product type is derived from the collection ID (`PleiadesNeoArchiveMono/Multi`, `PleiadesArchiveMono`, or `SPOTArchive1.5Mono`). For bundles requesting a DEM or projection, additional options are resolved by querying the OneAtlas contract options endpoint. Returns a `salesOrderId` and a `customerReference` of the form `<workspace>_<timestamp>`.
+
+5. **Publish "ordered" status** — Updates the STAC item with `order:status = ordered` and writes it to the workspace S3 bucket, then sends a Pulsar message on the `transformed` topic.
+
+6. **Poll S3 for delivery** — Waits up to 24 hours for Airbus to deliver an archive matching `<customerReference>*<acquisitionId>.zip` in the commercial data bucket.
+
+7. **Extract archive** — Downloads and extracts the `.zip` archive into a local directory named after the customer reference.
+
+8. **Publish "succeeded" status** — Updates the STAC item with `order:status = succeeded`, rewrites asset `href` values to their S3 paths, and writes a local STAC catalog/collection/item bundle as the CWL output directory.
+
+### SAR
+
+The SAR pipeline follows the same structure with these differences:
+
+- **In-progress check** — Before submitting, queries the Airbus SAR API (`sar.api.oneatlas.airbus.com/v1/sar/orders/*/items/status`) to check whether an order for the acquisition is already in a `submitted` state.
+- **Submit order** — POSTs to `https://sar.api.oneatlas.airbus.com/v1/sar/orders/submit`. Order options are a flat structure of `productType`, `orbitType`, `gainAttenuation`, and optionally `mapProjection` and `resolutionVariant`.
+- **Poll S3 for delivery** — Waits up to **7 days** (vs 24 hours for optical) to accommodate manual confirmation steps between Airbus and the customer. Archives are matched by prefix `SO_<orderId>` with suffix `.tar.gz`.
+- **Extract archive** — Downloads and extracts `.tar.gz` archives.
+
+On failure at any step, both adaptors write `order:status = failed` and an `order_failure_reason` string to the STAC record.
+
+## STAC Order State Machine
+
+State transitions use the [STAC Order extension](https://github.com/stac-extensions/order) fields (`order:status`, `order:id`, `order:date`):
+
+```puml
+@startuml
+hide empty description
+
+[*] --> orderable
+orderable --> ordered
+ordered --> succeeded
+ordered --> failed
+
+@enduml
+```
+
+## Optical Product Bundles
+
+| Bundle | Processing Level | Bit Depth | Radiometric | Spectral |
+|---|---|---|---|---|
+| `Visual` | ortho | 8-bit | display | pansharpened natural colour |
+| `General Use` | ortho | 12-bit | reflectance | pansharpened |
+| `Analytic` | ortho | 12-bit | reflectance | bundle |
+| `Basic` | primary | 12-bit | basic | bundle |
+
+## SAR Product Options
+
+| Option | Values |
+|---|---|
+| `product_type` | `SSC`, `MGD`, `GEC`, `EEC` |
+| `orbit` | `rapid`, `science` |
+| `resolution` | `RE`, `SE` |
+| `projection` | `auto`, `UTM`, `UPS` |
+
+## Configuration — Kubernetes Secrets
+
+The adaptor reads two values from the Kubernetes Secret `otp-airbus` in the workspace namespace (`ws-<workspace>`):
+
+| Key | Purpose |
+|---|---|
+| `otp` | Base64-encoded One-Time Pad key used to decrypt the Airbus API key stored in AWS Secrets Manager |
+| `contracts` | Base64-encoded JSON object mapping contract IDs to their type strings (e.g. `{"<id>": "PNEO", "<id>": "LEGACY"}`) |
+
+The encrypted API key is stored in AWS Secrets Manager under the secret ID `ws-<workspace>-<CLUSTER_PREFIX>`, keyed by `airbus`.
+
+For detailed operator guidance including sanity-check commands, see [Data Adaptors — Airbus workspace secrets](data-adaptors.md#airbus-workspace-secrets-operator-reference).
+
+## Key Dependencies
+
+| Package | Role |
+|---|---|
+| `pystac` | STAC item parsing and serialisation |
+| `boto3` | S3 read/write and AWS Secrets Manager access |
+| `kubernetes` | Reading OTP keys and contract IDs from Kubernetes Secrets |
+| `pulsar-client` | Pulsar producer for downstream event notification |
+| `requests` | Airbus OneAtlas REST API calls |

--- a/docs/reference/services/data-adaptors.md
+++ b/docs/reference/services/data-adaptors.md
@@ -12,7 +12,7 @@ tags:
 
 ## Summary
 
-Data adaptors enable ordering of commercial data from Airbus and Planet within the EO DataHub. These adaptors run as user service workflows in specialised data provider workspaces via the [Workflow Runner](workflow-runner.md) service.
+Data adaptors enable ordering of commercial data from Airbus, Planet, and Open Cosmos within the EO DataHub. These adaptors run as user service workflows in specialised data provider workspaces via the [Workflow Runner](workflow-runner.md) service.
 
 Each adaptor interfaces with its respective provider to place an order for a single item, waits for delivery to an S3 bucket, then downloads and attaches assets to a STAC item that tracks the order. The Workflow Runner manages asset upload and ingestion of STAC items into the user's workspace.
 
@@ -24,10 +24,17 @@ Each adaptor interfaces with its respective provider to place an order for a sin
 - Container images:
   - `public.ecr.aws/eodh/airbus-optical-adaptor`
   - `public.ecr.aws/eodh/airbus-sar-adaptor`
+- See [Airbus Adaptor](airbus-adaptor.md) for full reference (inputs, pipeline steps, product bundles, SAR options).
 
 **Planet:**
 - Container image:
   - `public.ecr.aws/eodh/planet-adaptor`
+- See [Planet Adaptor](planet-adaptor.md) for full reference (inputs, pipeline steps, product bundles, secrets).
+
+**Open Cosmos:**
+- Container image:
+  - `public.ecr.aws/eodh/open-cosmos-adaptor`
+- See [Open Cosmos Adaptor](open-cosmos-adaptor.md) for full reference (inputs, pipeline steps, secrets).
 
 ### Dependent Services
 

--- a/docs/reference/services/open-cosmos-adaptor.md
+++ b/docs/reference/services/open-cosmos-adaptor.md
@@ -1,0 +1,90 @@
+---
+title: Open Cosmos Adaptor
+doc_status: unreviewed
+tags:
+  - commercial-data
+  - stac
+  - workflows
+last_reviewed:
+reviewed_by:
+review_notes:
+---
+# Open Cosmos Adaptor
+
+Reference for the Open Cosmos commercial data adaptor, which orders satellite imagery from the Open Cosmos DataCosmos API and delivers it into an EO DataHub workspace. It runs as a short-lived Kubernetes pod orchestrated by a CWL (Common Workflow Language) workflow, and terminates after completing or failing each order batch.
+
+**How-to:** [Test commercial data adaptor changes](../../how-to/data-and-catalogues/test-commercial-data-adaptor.md) · **Explanation:** [Commercial Data Purchasing Pipeline](../../explanation/architecture/commercial-data-purchasing.md)
+
+## Execution Model
+
+The CWL workflow (`open-cosmos.cwl`) wraps a single `CommandLineTool` step that pulls a Docker image and invokes `python -m open_cosmos_adaptor`. The CWL runner passes positional arguments and injects `CLUSTER_PREFIX` as an environment variable. The tool's output is the working directory (`.`), which contains the STAC records written during execution.
+
+- **Container image:** `public.ecr.aws/eodh/open-cosmos-adaptor:0.1.0`
+- **Source code:** [EO-DataHub/commercial-data-adaptors](https://github.com/EO-DataHub/commercial-data-adaptors)
+
+## Inputs
+
+| Parameter | Description |
+|---|---|
+| `workspace` | Workspace identifier within the platform |
+| `workspace_bucket` | S3 bucket where workspace STAC records are stored |
+| `commercial_data_bucket` | S3 bucket used to receive commercial data |
+| `pulsar_url` | Apache Pulsar broker URL for downstream event messaging |
+| `cluster_prefix` | Platform environment prefix (injected as `CLUSTER_PREFIX`) |
+| `stac_key` | Directory containing one or more STAC catalogs describing items to order |
+| `coordinates` | Area of interest coordinates (passed through; not currently consumed by the Python) |
+
+## Processing Pipeline
+
+For each STAC item found in the input catalogs, the adaptor executes these steps in sequence, aborting the item and writing a failure record on any error:
+
+1. **Authenticate** — Obtains an OAuth2 bearer token via the client credentials flow against `login.open-cosmos.com`, using `CLIENT_ID` and `CLIENT_SECRET` sourced from Kubernetes secrets. The token is cached in-process.
+
+2. **Resolve contract** — Fetches the organisation's data-access policies from the Open Cosmos DPAP API to identify the default contract ID. `ORGANIZATION_ID` is also sourced from Kubernetes secrets.
+
+3. **Submit order** — POSTs an `IMAGE` order to the Open Cosmos orders API, specifying the collection ID, item ID, and processing level from the STAC item's `processing:level` property. The order must return a `PAID` status to proceed.
+
+4. **Publish "ordered" status** — Updates the STAC item with `order:status = ordered` and `order:id`, writes it to two S3 paths in the workspace bucket (a raw path and a `transformed/catalogs/…` path), then sends a Pulsar message on the `transformed` topic to notify downstream catalog ingestion services.
+
+5. **Download assets** — Streams each asset file from the Open Cosmos API to a local directory named after the order ID, using the bearer token for authentication.
+
+6. **Upload to S3** — Uploads the downloaded asset files to the workspace S3 bucket via boto3.
+
+7. **Publish "succeeded" status** — Updates the STAC item with `order:status = succeeded`, rewrites asset `href` values to their S3 paths, and writes a local STAC catalog/collection/item bundle as the CWL output directory.
+
+On failure at any step, the adaptor writes `order:status = failed` and an `order_failure_reason` string to the STAC record before exiting.
+
+## STAC Order State Machine
+
+State transitions use the [STAC Order extension](https://github.com/stac-extensions/order) fields (`order:status`, `order:id`, `order:date`):
+
+```puml
+@startuml
+hide empty description
+
+[*] --> orderable
+orderable --> ordered
+ordered --> succeeded
+ordered --> failed
+
+@enduml
+```
+
+## Configuration — Kubernetes Secrets
+
+Three values must be present as environment variables, typically mounted from a Kubernetes Secret:
+
+| Variable | Purpose |
+|---|---|
+| `CLIENT_ID` | Open Cosmos OAuth2 client ID |
+| `CLIENT_SECRET` | Open Cosmos OAuth2 client secret |
+| `ORGANIZATION_ID` | Open Cosmos organisation identifier (used to resolve the default contract) |
+
+## Key Dependencies
+
+| Package | Role |
+|---|---|
+| `pystac` | STAC item parsing and serialisation |
+| `boto3` | S3 read/write |
+| `pulsar-client` | Pulsar producer for downstream event notification |
+| `requests` | Open Cosmos REST API calls |

--- a/docs/reference/services/planet-adaptor.md
+++ b/docs/reference/services/planet-adaptor.md
@@ -1,0 +1,124 @@
+---
+title: Planet Adaptor
+doc_status: unreviewed
+tags:
+  - commercial-data
+  - stac
+  - workflows
+last_reviewed:
+reviewed_by:
+review_notes:
+---
+# Planet Adaptor
+
+Reference for the Planet commercial data adaptor, which orders satellite imagery from the Planet Orders API and delivers it into an EO DataHub workspace. It runs as a short-lived Kubernetes pod orchestrated by a CWL workflow, and terminates after completing or failing each order batch.
+
+**How-to:** [Test commercial data adaptor changes](../../how-to/data-and-catalogues/test-commercial-data-adaptor.md) · **Explanation:** [Commercial Data Purchasing Pipeline](../../explanation/architecture/commercial-data-purchasing.md)
+
+## Execution Model
+
+The CWL workflow (`planet.cwl`) wraps a single `CommandLineTool` step that pulls a Docker image and invokes `python -m planet_adaptor`. The CWL runner passes seven positional arguments and injects `CLUSTER_PREFIX` as an environment variable. The tool's output is the working directory (`.`), which contains the STAC records written during execution.
+
+- **Container image:** `public.ecr.aws/eodh/planet-adaptor:0.1.8`
+- **Source code:** [EO-DataHub/commercial-data-adaptors](https://github.com/EO-DataHub/commercial-data-adaptors)
+
+## Inputs
+
+| Parameter | Description |
+|---|---|
+| `workspace` | Workspace identifier within the platform |
+| `workspace_bucket` | S3 bucket where workspace STAC records are stored |
+| `commercial_data_bucket` | S3 bucket where Planet delivers order files |
+| `pulsar_url` | Apache Pulsar broker URL for downstream event messaging |
+| `cluster_prefix` | Platform environment prefix (injected as `CLUSTER_PREFIX`) |
+| `product_bundle` | Named bundle controlling image processing: `Visual`, `General Use`, `Analytic`, or `Basic` |
+| `coordinates` | Area of interest coordinates (JSON-stringified) |
+| `stac_key` | Directory containing one or more STAC catalogs describing items to order |
+
+## Processing Pipeline
+
+For each STAC item found in the input catalogs, the adaptor executes the following steps in sequence, aborting the item and writing a failure record on any error:
+
+1. **Authenticate** — Retrieves an OTP key from the Kubernetes Secret `otp-planet` in the workspace namespace, fetches the corresponding encrypted API key from AWS Secrets Manager (secret ID `ws-<workspace>-<CLUSTER_PREFIX>`, key `planet`), and decrypts it using XOR One-Time Pad. The plaintext key is passed to the Planet Python SDK as the API credential.
+
+2. **Resolve product bundle** — Looks up the product bundle name(s) for the item's `item_type` (derived from `properties.item_type` in the STAC item) and the requested bundle category. Raises an error if either the item type or bundle name is not in the supported set.
+
+3. **Check for existing order** — Queries the Planet Orders API for an existing order whose name matches `<item_id>-<workspace>`. If an order is in `queued` or `running` state, the adaptor fails immediately without consuming quota. If the order has already `succeeded`, the submission step is skipped and the existing order ID is reused.
+
+4. **Retrieve S3 delivery credentials** — Reads a dedicated set of AWS credentials from Kubernetes Secrets in the `ws-planet` namespace (`planet-aws-access-key-id` and `planet-aws-secret-access-key`). These are distinct from the API authentication credentials and are passed to Planet to authorise direct delivery to the commercial data bucket.
+
+5. **Submit order** — Uses the Planet Python SDK to POST an order to the Planet Orders API. The order specifies the item ID, item type, product bundle, delivery target (`planet/commercial-data/orders` prefix in the commercial data bucket), and — if coordinates are provided and the bundle supports it — an AOI clip tool. Basic PSScene bundles do not support clipping and request the full image. Bundles with a fallback (e.g. `analytic_8b_sr_udm2` falling back to `analytic_sr_udm2`) are specified using the SDK's `fallback_bundle` parameter. If a 400 error is returned and the item timestamp is less than 12 hours old, the error is surfaced as "assets not yet available" without consuming quota.
+
+6. **Publish "ordered" status** — Updates the STAC item with `order:status = ordered` and `order:id`, writes it to two S3 paths in the workspace bucket (a raw path and a `transformed/catalogs/…` path), then sends a Pulsar message on the `transformed` topic to notify downstream catalog ingestion services.
+
+7. **Poll S3 for delivery** — Polls the commercial data bucket for up to 24 hours (every 60 seconds) until Planet deposits a `manifest.json` file at `planet/commercial-data/orders/<order_id>/manifest.json`. The manifest's presence indicates the full order has been delivered.
+
+8. **Download assets** — Downloads all files under the `planet/commercial-data/orders/<order_id>/` prefix from S3 into a local directory named after the order ID. Any `.zip` files are extracted in place and the archive removed.
+
+9. **Publish "succeeded" status** — Walks the local order directory, classifies each file by regex into asset roles (manifest, metadata, UDM, primaryAsset), adds them to the STAC item's `assets` map with inferred MIME types, updates `order:status = succeeded`, and writes a local STAC catalog/collection/item bundle as the CWL output directory.
+
+On failure at any step, the adaptor writes `order:status = failed` and an `order_failure_reason` string to the STAC record before exiting.
+
+## STAC Order State Machine
+
+State transitions use the [STAC Order extension](https://github.com/stac-extensions/order) fields (`order:status`, `order:id`, `order:date`):
+
+```puml
+@startuml
+hide empty description
+
+[*] --> orderable
+orderable --> ordered
+ordered --> succeeded
+ordered --> failed
+
+@enduml
+```
+
+## Product Bundles
+
+Bundle names map to Planet bundle identifiers per item type. Where two names are listed, the second is a fallback used if the primary is unavailable.
+
+### PSScene
+
+| Bundle | Planet Bundle(s) | AOI Clipping |
+|---|---|---|
+| `Visual` | `visual` | yes |
+| `General Use` | `analytic_8b_sr_udm2` / `analytic_sr_udm2` | yes |
+| `Analytic` | `analytic_8b_sr_udm2` / `analytic_sr_udm2` | yes |
+| `Basic` | `basic_analytic_8b_udm2` / `basic_analytic_udm2` | no |
+
+### SkySatCollect
+
+| Bundle | Planet Bundle | AOI Clipping |
+|---|---|---|
+| `Visual` | `visual` | yes |
+| `General Use` | `pansharpened_udm2` | yes |
+| `Analytic` | `analytic_sr_udm2` | yes |
+| `Basic` | `analytic_udm2` | yes |
+
+## Configuration — Kubernetes Secrets
+
+Two separate sets of credentials are required, mounted from Kubernetes Secrets:
+
+**API authentication** — Secret `otp-planet` in the workspace namespace (`ws-<workspace>`):
+
+| Key | Purpose |
+|---|---|
+| `otp` | Base64-encoded One-Time Pad key used to decrypt the Planet API key stored in AWS Secrets Manager (secret ID `ws-<workspace>-<CLUSTER_PREFIX>`, key `planet`) |
+
+**S3 delivery** — in the `ws-planet` namespace:
+
+| Key | Purpose |
+|---|---|
+| `planet-aws-access-key-id` | AWS access key ID passed to Planet to authorise delivery into the commercial data bucket |
+| `planet-aws-secret-access-key` | Corresponding AWS secret access key |
+
+## Key Dependencies
+
+| Package | Role |
+|---|---|
+| `planet` | Planet Python SDK for order submission and status queries (async) |
+| `boto3` | S3 read/write and AWS Secrets Manager access |
+| `kubernetes` | Reading OTP keys and delivery credentials from Kubernetes Secrets |
+| `pulsar-client` | Pulsar producer for downstream event notification |


### PR DESCRIPTION
Integrates README content from the commercial-data-adaptors repo into dedicated reference pages, each covering execution model, inputs, processing pipeline, product bundles/options, STAC state machine (PlantUML), secrets config, and key dependencies. Updates data-adaptors.md to reference the new pages and adds Open Cosmos to the provider list.